### PR TITLE
Fix typo in CollectionManager

### DIFF
--- a/src/main/java/xyz/holocons/mc/holoitemsrevamp/collection/CollectionManager.java
+++ b/src/main/java/xyz/holocons/mc/holoitemsrevamp/collection/CollectionManager.java
@@ -732,8 +732,8 @@ public class CollectionManager {
         };
     }
 
-    private static Idol buildRoboco(HoloItemsRevamp plugins) {
-        return new Idol(new MagnetBook(plugins)) {
+    private static Idol buildRoboco(HoloItemsRevamp plugin) {
+        return new Idol(new MagnetBook(plugin)) {
 
             @Override
             public @NotNull String getSkinUrl() {


### PR DESCRIPTION
everyone else uses the singular, the word "plugins" only appears twice in this whole file and they're both right here